### PR TITLE
Fixed Capitalization and Grammar Errors on SteemAuto

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -6,7 +6,7 @@ if(isset($_POST['name']) && isset($_POST['email']) && isset($_POST['subject']) &
 	if(!isset($_POST['g-recaptcha-response'])){
 		echo '<div id="alert" class="alert alert-danger">
 					<span class="closebtn" onclick="this.parentElement.style.display=\'none\';">&times;</span>
-					Captcha is Not Set.
+					Captcha is not set.
 					</div>
 					<script>setTimeout(function(){ document.getElementById("alert").style.opacity = "0";setTimeout(function(){document.getElementById("alert").style.display = "none"; }, 10000) }, 10000);</script>';
 	}else{
@@ -24,7 +24,7 @@ if(isset($_POST['name']) && isset($_POST['email']) && isset($_POST['subject']) &
 		if($result->success == false){
 			echo '<div id="alert" class="alert alert-danger">
 					<span class="closebtn" onclick="this.parentElement.style.display=\'none\';">&times;</span>
-					Captcha is Wrong.
+					Captcha is wrong.
 					</div>
 					<script>setTimeout(function(){ document.getElementById("alert").style.opacity = "0";setTimeout(function(){document.getElementById("alert").style.display = "none"; }, 10000) }, 10000);</script>';
 		}else{

--- a/dash.php
+++ b/dash.php
@@ -811,12 +811,12 @@ if($auth == 0){ ?>
 <div class="card">
 <div class="content">
 <center>
-<h5 style="color:red;">Leave Steemauto if you don't know about it or you can't understand. You may harm your steem account.</h5>
+<h5 style="color:red;">Please leave Steemauto if you don't understand how it works or what it does. You could harm your Steem account if you change settings that you do not understand.</h5>
 <h3>Welcome <? echo $name; ?>,</h3>
-<br>Please add @steemauto to your Account's posting auths by One of following Apps:<br>
+<br>Please add @steemauto to your account's posting auths using one of following apps:<br>
 <br><a class="btn btn-success" href="https://steemconnect.com/authorize/@steemauto/?redirect_uri=https://steemauto.com/dash.php">SteemConnect (recommended)</a> or <a class="btn btn-success" href="https://steemauto.com/auth/">SteemAuto</a>
-<br><br>Both Are Secure.
-<br>otherwise, You will not be able to Use Our site.
+<br><br>Both are secure.
+<br>If you don't add @steemauto to your posting auths you will not be able to use our site.
 </center>
 </div>
 </div>
@@ -844,17 +844,17 @@ foreach($result as $x){
 			<div class="content">
 				<div class="card">
 					<div class="content">
-						<h5 style="color:red;">Leave Steemauto if you don't know about it or you can't understand. You may harm your steem account.</h5>
+						<h5 style="color:red;">Please leave Steemauto if you don't understand how it works or what it does. You could harm your Steem account if you change settings that you do not understand.</h5>
 						<h3>Welcome <? echo $name; ?>,</h3>
 
-						<br>Please Choose One:<br>
+						<br>Please choose an option:<br>
 						<a href="dash.php?i=1" class="btn btn-primary">Curation Trail</a>
 						<a href="dash.php?i=2" class="btn btn-primary">Fan Base</a><br>
 						<a style="margin-top:5px;" href="dash.php?i=13" class="btn btn-primary">Upvote Comments</a>
-						<a style="margin-top:5px;" href="dash.php?i=11" class="btn btn-primary">Scheduled Posts</a><br>
+						<a style="margin-top:5px;" href="dash.php?i=11" class="btn btn-primary">Schedule Posts</a><br>
 						<a style="margin-top:5px;" href="dash.php?i=16" class="btn btn-primary">Claim Rewards</a><br><hr>
-						<p>You can remove steemauto access from your account:</p><p>(by steemconnect)</p>
-						<a href="https://steemconnect.com/revoke/@steemauto" class="btn btn-danger">UnAuthorize (Leaving SteemAuto)</a>
+						<p>You can remove SteemAuto's access from your account by using SteemConnect</p>
+						<a href="https://steemconnect.com/revoke/@steemauto" class="btn btn-danger">Unauthorize (Leave SteemAuto)</a>
 					</div>
 				</div>
 			</div>
@@ -881,10 +881,10 @@ foreach($result as $x){
 						<input id="powerlimit" name="powerlimit" class="form-control" type="number" min="1" max="99" step="0.01" required>
 						<input style="margin-top:5px;" type="submit" value="submit" class="btn btn-primary">
 					</form><br>
-					<p>All your upvotes will be paused if your voting power went lower than voting power limit.</p>
+					<p>All your upvotes will be paused if your voting power is lower than the voting power limit.</p>
 					<p>Your voting power will updated every 5 minutes.</p>
-					<p>Read more about voting power in steemit FAQ.</p>
-					<p>You can check your voting power here: https://steemd.com/@<? echo $name; ?></p>
+					<p>Read more about voting power in the Steemit FAQ.</p>
+					<p>You can check your voting power here: <a href="https://steemd.com/@<? echo $name; ?>">https://steemd.com/@<? echo $name; ?></a></p>
 					
 				</div>
 			</div>
@@ -897,7 +897,7 @@ foreach($result as $x){
 	include('inc/trail.php');
 }elseif($a == 2){ //Fanbase
 	include('inc/fanbase.php');
-}elseif($a == 11){ // Scheduled Posts
+}elseif($a == 11){ // Schedule Posts
 	include('inc/scheduled.php');
 }elseif($a == 13){ // Comment upvotes
 	include('inc/commentupvote.php');

--- a/faq.php
+++ b/faq.php
@@ -44,9 +44,9 @@ require_once('header.php');
 				You can also sumbit a short description and become a "trail" which other users will be able to follow. 
 				Note: For upvoting an user's authored posts, you should use Fanbase. Curation trails will not follow self upvotes.</p>
 				
-				<h3>What is the difference between 'Scale' and 'Fixed' in following curation trails?</h3>
+				<h3>What is the difference between 'Scale' and 'Fixed' options when following curation trails?</h3>
 				<p>Fixed voting weight means you will upvote with exact percentage you entered.<br>
-				Scale voting weight means your voting weight will be changed (i.e. scaled) by the trail's voting weight. For example, if you followed a trail with this option set to 10% then if trail upvotes a post by 50%, your upvote weight will be 5% (10% of 50%) </p>
+				Scaled voting weight means your voting weight will be changed (i.e. scaled) by the trail's voting weight. For example, if you followed a trail with this option set to 10% then if that trail upvotes a post by 50%, your upvote weight will be 5% (10% of 50%) </p>
 				
 				<h3>What is a Fanbase?</h3>
 				<p>By using the 'Fanbase' section, you can automatically upvote your favorite authors immediately after they publish any post (not comments). 

--- a/faq.php
+++ b/faq.php
@@ -52,6 +52,10 @@ require_once('header.php');
 				<p>No. In other tools if you upvote any post twice with different upvote weights, the first upvote is overriden by the second upvote. 
 				In the Steemauto this problem is fixed. You can upvote any post manually before applying auto upvotes and the manual vote will not be overriden.</p>
 				
+				<h3>What is difference between 'Scale' and 'Fixed' in following trails?</h3>
+				<p>Fixed voting weight means you will upvote with exact percentage you entered.<br>
+				Scale voting weight means your voting weight will changed by trail voted weight. Let's say you followed a trail by this method with 10% then if trail upvotes any post by 50%, your upvote weight will be 5% (10% of 50%) </p>
+				
 				<h3>Any other questions?</h3>
 				<p>Ask your questions on the <a href="/contact.php" target="_blank">Contact</a> page.</p>
 				

--- a/faq.php
+++ b/faq.php
@@ -44,6 +44,10 @@ require_once('header.php');
 				You can also sumbit a short description and become a "trail" which other users will be able to follow. 
 				Note: For upvoting an user's authored posts, you should use Fanbase. Curation trails will not follow self upvotes.</p>
 				
+				<h3>What is the difference between 'Scale' and 'Fixed' in following curation trails?</h3>
+				<p>Fixed voting weight means you will upvote with exact percentage you entered.<br>
+				Scale voting weight means your voting weight will be changed (i.e. scaled) by the trail's voting weight. For example, if you followed a trail with this option set to 10% then if trail upvotes a post by 50%, your upvote weight will be 5% (10% of 50%) </p>
+				
 				<h3>What is a Fanbase?</h3>
 				<p>By using the 'Fanbase' section, you can automatically upvote your favorite authors immediately after they publish any post (not comments). 
 				You can configure the 'upvote weight' for each user on the 'Fanbase' page. </p>
@@ -51,10 +55,6 @@ require_once('header.php');
 				<h3>Will my upvotes be replaced if I manually upvoted a post?</h3>
 				<p>No. In other tools if you upvote any post twice with different upvote weights, the first upvote is overriden by the second upvote. 
 				In the Steemauto this problem is fixed. You can upvote any post manually before applying auto upvotes and the manual vote will not be overriden.</p>
-				
-				<h3>What is difference between 'Scale' and 'Fixed' in following trails?</h3>
-				<p>Fixed voting weight means you will upvote with exact percentage you entered.<br>
-				Scale voting weight means your voting weight will changed by trail voted weight. Let's say you followed a trail by this method with 10% then if trail upvotes any post by 50%, your upvote weight will be 5% (10% of 50%) </p>
 				
 				<h3>Any other questions?</h3>
 				<p>Ask your questions on the <a href="/contact.php" target="_blank">Contact</a> page.</p>

--- a/faq.php
+++ b/faq.php
@@ -16,44 +16,44 @@ require_once('header.php');
 			<div class="content faq" style="padding-left:30px; padding-right:30px;">
 				<center><h2 class="head">Frequently Asked Questions</h2></center>
 				<hr>
-				<h3>How Steemauto works?</h3>
-				<p>Steemauto will use your account posting authority to post, upvote, claim rewards and etc.</p>
+				<h3>How does SteemAuto work?</h3>
+				<p>Steemauto uses your account posting authority to post, upvote, and claim rewards for you automatically.</p>
 				
-				<h3>I sent money, why I can't login?</h3>
+				<h3>I've sent money, why can't I login?</h3>
 				<p>Go to your wallet and make sure you sent exactly 0.001 SBD. Then try again.</p>
 				
 				<h3>What is posting authority?</h3>
-				<p>In the steem blockchain, each account have some keys to access to the account. One of these keys are 'posting key' which can be used to post, comment, upvote, follow, and etc. By using posting key, you can't access to account's balances.</p>
+				<p>In the Steem blockchain, each account have different keys that let you access different parts of the account. One of these keys is the 'posting key' which can be used to post, comment, upvote, follow, and etc. When using a posting key you can't access an account's balances, so your funds are perfectly safe.</p>
 				
-				<h3>Is Steemauto secure?</h3>
-				<p>Steemauto is an open source app which you can see all source of it in the our <a href="https://github.com/mahdiyari/steemauto" target="_blank">GitHub repository</a>.</p>
+				<h3>Is SteemAuto secure?</h3>
+				<p>SteemAuto is an open source app. You can view all of its source code at its <a href="https://github.com/mahdiyari/steemauto" target="_blank">GitHub repository</a>.</p>
 				
-				<h3>Why should I enter my password in the steemconnect.com?</h3>
-				<p>We are using steemconnect.com to broadcast a transaction which will allow @steemauto to use your account posting authority and broadcasting transactions needs your password.
+				<h3>Why should I enter my password at steemconnect.com?</h3>
+				<p>We are using steemconnect.com to broadcast the transaction which will allow @steemauto to use your account posting authority. To broadcasting this (and any) transaction you will need to input your password.
 				Of course, you can remove this access any time by clicking on 'Unauthorize' button in your dashboard. </p>
 				
 				<h3>Do you have any access to my account balance?</h3>
-				<p>No. @steemauto can only publish a post, upvote, follow, resteem, claim rewards.</p>
+				<p>No, SteemAuto can only publish a post, upvote, follow, resteem, and claim rewards. It can not access your account balance in any way.</p>
 				
-				<h3>Steemauto will use my account without my permission?</h3>
-				<p>No. Steemauto only will work by the settings which you configured in your account.</p>
+				<h3>Will SteemAuto use my account without my permission?</h3>
+				<p>No, Steemauto will always operate by the settings which you configured in your account.</p>
 				
-				<h3>What is the Curation trail?</h3>
-				<p>By using 'Curation trail' section, you will be able to upvote on the posts (not comments) which are upvoted by the selected user. 
-				You will be able to configure 'upvote weight' for each user in that page. 
-				You can submit a short description and become a 'trail' which other users will be able to follow your upvotes. 
-				Note: for upvoting that user's authored posts, you should use Fanbase. Curtaion trail will not follow self upvotes.</p>
+				<h3>What is a Curation Trail?</h3>
+				<p>By using the 'Curation Trail' section, you can automatically upvote the posts (not comments) which are upvoted by the selected user. 
+				You can configure the 'upvote weight' for each user on the 'Curation Trail' page. 
+				You can also sumbit a short description and become a "trail" which other users will be able to follow. 
+				Note: For upvoting an user's authored posts, you should use Fanbase. Curation trails will not follow self upvotes.</p>
 				
-				<h3>What is the Fanbase?</h3>
-				<p>You can upvote your favorite authors immediately after publishing any post (not comments). 
-				You will be able to configure 'upvote weight' for each user in that page. </p>
+				<h3>What is a Fanbase?</h3>
+				<p>By using the 'Fanbase' section, you can automatically upvote your favorite authors immediately after they publish any post (not comments). 
+				You can configure the 'upvote weight' for each user on the 'Fanbase' page. </p>
 				
-				<h3>My upvotes will be replaced?</h3>
-				<p>No. In the other tools, if you upvote any post twice with different 'upvote weight', second upvote will be replaced with the old upvote. 
-				But, in the Steemauto that is fixed. You can upvote any post manually before applying auto upvotes.</p>
+				<h3>Will my upvotes be replaced if I manually upvoted a post?</h3>
+				<p>No. In other tools if you upvote any post twice with different upvote weights, the first upvote is overriden by the second upvote. 
+				In the Steemauto this problem is fixed. You can upvote any post manually before applying auto upvotes and the manual vote will not be overriden.</p>
 				
-				<h3>Any other question?</h3>
-				<p>Ask your questions from the <a href="/contact.php" target="_blank">Contact</a> page.</p>
+				<h3>Any other questions?</h3>
+				<p>Ask your questions on the <a href="/contact.php" target="_blank">Contact</a> page.</p>
 				
 				<h3>Useful articles:</h3>
 				<p><a href="https://steemit.com/guide/@scrooger/steemauto-full-guide-and-how-to-register" target="_blank">STEEMAUTO - Full guide and how to REGISTER</a> by @scrooger</p>

--- a/header.php
+++ b/header.php
@@ -90,13 +90,13 @@ if(isset($_COOKIE['luser']) && isset($_COOKIE['lpw'])){
 		<li <? if($active ==3){echo 'class="active"';} ?>>
 			<a href="dash.php?i=2">
 				<i class="pe-7s-like"></i>
-				<p>Fan Base</p>
+				<p>Fanbase</p>
 			</a>
 		</li>
 		<li <? if($active ==4){echo 'class="active"';} ?>>
 			<a href="dash.php?i=11">
 				<i class="pe-7s-date"></i>
-				<p>Scheduled Posts</p>
+				<p>Schedule Posts</p>
 			</a>
 		</li>
 		<li <? if($active ==6){echo 'class="active"';} ?>>

--- a/inc/claimreward.php
+++ b/inc/claimreward.php
@@ -16,11 +16,11 @@ if($x == 1){
 		<div class="card">
 			<div class="content">
 				<h3>Welcome <? echo $name; ?>,</h3><br>
-				Here you can Enable or Disable claiming rewards automatically to your account balance.<br><br>
-				<strong>More info:</strong> Usually you should redeem your steemit curation and author rewards by clicking on a button in your wallet in steemit.com<br>
-				by this tool you don't need to click on that button manually! it will do that job for you automatically.<br>
-				this tool will check your account every 5 minutes and will transfer your rewards to your balance.<br>
-				and such as always, your balance is safe! (because of using posting authority)<br><br>
+				Here you can enable or disable SteemAuto from automatically claiming your rewards.<br><br>
+				<strong>More info:</strong> Usually you redeem your Steemit curation and author rewards by clicking on a button in your wallet on steemit.com<br>
+				This handy tool means you don't need to click on that button manually, since it does that job for you automatically!<br>
+				Every five minutes this tool will check your account and will transfer your pending rewards to your balance.<br>
+				This tool is safe to use because SteemAuto only has access to your posting authority. That means it can only claim your rewards and cannot access any of the funds in your wallet.<br><br>
 				<strong>Status:</strong> 
 				<? if($claimreward==0){ ?>
 				<span style="color:red;">Disabled</span>

--- a/inc/commentupvote.php
+++ b/inc/commentupvote.php
@@ -5,14 +5,14 @@
 			<div class="card"> <!-- 4 -->
 				<div class="content"> <!-- 5 -->
 					<h3>Welcome <? echo $name; ?>,</h3><br>
-					in this page you will be able to upvote your post's comments automatically.<br>
-					Each user will get only one upvote on each post and Maximum 2 upvotes per day(UTC), even if they write more comments.<br>
-					Remember to configure Voting weight and Wait time before upvoting.<br>
+					This page lets you upvote an user's comments automatically.<br>
+					Each user will get only one upvote on each post they comment on and a maximum of two upvotes per day (UTC), even if they write more comments.<br>
+					Remember to configure the upvote weight and wait time.<br>
 					<center><a class="btn btn-success" style="margin-top:8px;" onclick="$('#addusertolist').toggle(500);">Add a User to the List</a></center>
 					<form style="display:none;" id="addusertolist" onsubmit="addusertolist();return false;">
 					<hr>
 					<h4>Fill the form and Click on Submit:</h4>
-						<label>Commenter Steemit Username without @:</label>
+						<label>Commenter's Steemit Username without @:</label>
 						<input id="username" placeholder="For example: mahdiyari" name="username" type="text" class="form-control" required/>
 						<label>Upvote Weight (%):</label>
 						<input id="weight" placeholder="For example: 50" name="weight" type="number" step="0.01" min="0.01" max="100" class="form-control" required/>
@@ -120,4 +120,3 @@
 	}
 	?>
 </div>
-	

--- a/inc/fanbase.php
+++ b/inc/fanbase.php
@@ -7,7 +7,7 @@
 	<div class="content">
 	<h3>Welcome <? echo $name; ?>,</h3><br>
 
-	Here you can see a List of Popular Authors and upvote them.<br>
+	Here you can see a list of the most popular authors and upvote them.<br>
 	Follow someone to auto upvote that user's posts.
 	<form style="display:;" id="become" onsubmit="follow2(); return false;">
 	<label>Username:</label>

--- a/inc/js.php
+++ b/inc/js.php
@@ -11,7 +11,7 @@ function follow(user){
 			if(this.responseText == 1){	
 				$.notify({
 					icon: 'pe-7s-check',
-					message: "Successfully Followed by 50% upvote weight! you can access this setting after reloading page."
+					message: "Successfully followed with 50% upvote weight! You can access this setting after reloading the page."
 				},{
 					type: 'success',
 					timer: 6000
@@ -210,7 +210,7 @@ function follow1(user){
 			if(this.responseText == 1){	
 				$.notify({
 					icon: 'pe-7s-check',
-					message: "Successfully Followed by 100% upvote weight! you can access this setting after reloading page."
+					message: "Successfully followed with 100% upvote weight! You can access this setting after reloading the page."
 				},{
 					type: 'success',
 					timer: 6000
@@ -295,7 +295,7 @@ function follow2(){
 			if(this.responseText == 1){	
 				$.notify({
 					icon: 'pe-7s-check',
-					message: "Successfully Followed by 100% upvote weight! you can access this setting after reloading page."
+					message: "Successfully followed with 100% upvote weight! You can access this setting after reloading the page."
 				},{
 					type: 'success',
 					timer: 6000

--- a/inc/list.php
+++ b/inc/list.php
@@ -13,7 +13,7 @@ if(isset($_GET['user']) && $_GET['user'] !='' && isset($_GET['id']) && is_numeri
 				<div class="card">
 					<div class="content">
 						<h3>Welcome <? echo $name; ?>,</h3><br>
-						Here is the List of Enabled users who followed <span style="color:red;"><? if($i == 1){echo 'Trail';}else{echo 'Fan';} ?></span>: @<? echo $followed; ?>
+						Here is a list of the SteemAuto users who are part of @<? echo $followed; ?>'s <span style="color:red;"><? if($i == 1){echo 'Curation Trail';}else{echo 'Fanbase';} ?></span>.
 					</div>
 				</div>
 				</div>

--- a/inc/scheduled.php
+++ b/inc/scheduled.php
@@ -6,12 +6,12 @@
 	<div class="card">
 	<div class="content">
 	<h3>Welcome <? echo $name; ?>,</h3><br>
-	Here you can add a Post to published in the future.
+	This page is where you can schedule a post to published in the future.
 	
 	<form style="display:;" id="post" onsubmit="post(); return false;">
 	<label for="title">Title:</label>
 	<input id="title" placeholder="Post Title" name="title" type="text" class="form-control" required>
-	<label for="content">Content: (You can Write in Steemit.com and Copy Markdown or Raw Html Here.)</label>
+	<label for="content">Content: (You can write your post on Steemit.com and copy the markdown or raw HTML Here.)</label>
 	<textarea id="content" placeholder="Post Content" name="content" type="text" class="form-control" required></textarea>
 	<label for="tags">Tags:</label>
 	<input id="tags" placeholder="tag1 tag2 tag3 tag4 tag5" name="tags" type="text" class="form-control" required>

--- a/inc/trail.php
+++ b/inc/trail.php
@@ -22,7 +22,7 @@ if(isset($_GET['trail']) && $_GET['trail'] != ''){
 				<div class="col-md-6"> <!-- 3 -->
 					<div class="card"> <!-- 4 -->
 						<div class="content"> <!-- 5 -->
-							<h3>Searching for trail: </h3><br>
+							<h3>Searching for "<span><? echo htmlspecialchars($_GET['trail']); ?></span>": </h3><br>
 							<? 
 							$stmt = $conn->prepare("SELECT EXISTS(SELECT * FROM `trailers` WHERE `user`=?)");
 							$searchedtrail = $_GET['trail'];
@@ -48,9 +48,9 @@ if(isset($_GET['trail']) && $_GET['trail'] != ''){
 								}
 								
 								?>
-								<strong>Trail name:</strong><span> <? echo htmlspecialchars($searchedtrail); ?></span><br>
+								<strong>Trail Name:</strong><span> <? echo htmlspecialchars($searchedtrail); ?></span><br>
 								<strong>Description:</strong><span> <? echo htmlspecialchars($row['description']); ?></span><br>
-								<strong>Followers:</strong><span> <? echo $row['followers']; ?> (<a href="/dash.php?i=15&id=1&user=<? echo htmlspecialchars($searchedtrail); ?>">Show enable followers</a>)</span><br><br>
+								<strong>Followers:</strong><span> <? echo $row['followers']; ?> (<a href="/dash.php?i=15&id=1&user=<? echo htmlspecialchars($searchedtrail); ?>">View followers</a>)</span><br><br>
 								<? if($alreadyfollowed){ ?>
 									<button onclick="if(confirm('Are you sure?')){unfollow('<? echo $row['user']; ?>');};" class="btn btn-danger" <? if($row['user'] == $name){echo 'disabled="disabled"';} ?>>UNFOLLOW</button>
 									<button onclick="showset('1');" class="btn btn-primary" <? if($row['user'] == $name){echo 'disabled="disabled"';} ?>>Settings</button>
@@ -112,7 +112,7 @@ if(isset($_GET['trail']) && $_GET['trail'] != ''){
 								
 								<?	
 							}else{ ?>
-								<p style="color:red;">Can't find. That Trail should register on steemauto and become a trail.</p>
+								<p style="color:red;">Sorry, that curation trail does not exist. If that account belongs to you, sign up on SteemAuto and create a trail.</p>
 							<?
 							}
 							?>
@@ -130,12 +130,12 @@ if(isset($_GET['trail']) && $_GET['trail'] != ''){
 <div class="card"> <!-- 4 -->
 <div class="content"> <!-- 5 -->
 <h3>Welcome <? echo $name; ?>,</h3><br>
-Here you can see a List of Curation Trailers and follow them.<br>
-By following a Trail, you will upvote automatically each posts that trail will upvote.<br>
-or, you can: <a style="margin:5px;" class="btn btn-success" onclick="showbecome();">become/edit your Trailer</a>
+Here you can view a list of existing curation trails and follow them.<br>
+Following a curation trail means that you will automatically upvote each post that the trail upvotes.<br>
+If you don't want to follow a trail you can also: <a style="margin:5px;" class="btn btn-success" onclick="showbecome();">create/edit your curation trail</a>
 <form style="display:none;" id="become" onsubmit="become(); return false;">
 <label>Short Description:(max 100 character)</label>
-<textarea id="description" placeholder="For example: I'm voting only Good posts." name="description" type="text" class="form-control" required>
+<textarea id="description" placeholder="For example: I'm voting only for good posts." name="description" type="text" class="form-control" required>
 </textarea>
 <input style="margin-top:10px;"value="Submit" type="submit" class="btn btn-primary">
 </form>
@@ -152,7 +152,7 @@ or, you can: <a style="margin:5px;" class="btn btn-success" onclick="showbecome(
 			<div class="content"> <!-- content -->
 
 
-				<h3 style="border-bottom:1px solid #000; padding-bottom:10px;">You Are following:</h3>
+				<h3 style="border-bottom:1px solid #000; padding-bottom:10px;">You are following:</h3>
 
 				<div style="max-height:600px; overflow:auto;" class="table-responsive-vertical shadow-z-1"> <!-- 8 -->
 
@@ -339,7 +339,7 @@ or, you can: <a style="margin:5px;" class="btn btn-success" onclick="showbecome(
 		<div class="card"> <!-- card -->
 			<div class="content"> <!-- content -->
 				<!-- -->	
-				<h3 style="border-bottom:1px solid #000; padding-bottom:10px;">Top Trailers: </h3>
+				<h3 style="border-bottom:1px solid #000; padding-bottom:10px;">Popular Curation Trails: </h3>
 
 				<? 
 				$result = $conn->query("SELECT EXISTS(SELECT * FROM `trailers` ORDER BY `trailers`.`followers` DESC LIMIT $mysqlpage,20)");

--- a/index.php
+++ b/index.php
@@ -21,7 +21,7 @@ require_once('he_ad.php');
 						<h2 class="featurette-heading">
 							<i style="color:#0179ff;" class="text-muted">Steem<i style="color:#05ab05;">Auto</i></i>
 						</h2>
-						<p class="lead">SteemAuto comes with amaizing features, Schedule post, Build a Fanbase, or leave a curation trail for users all around the world to follow. </p>
+						<p class="lead">SteemAuto comes with many amazing features. You can use it to schedule posts, build fanbases, create curation trails, and automatically claim your rewards. </p>
 					</div>
 				</div>
 			</div>
@@ -32,7 +32,7 @@ require_once('he_ad.php');
 					<div class="content">
 						
 						<iframe width="100%" height="315" src="https://www.youtube.com/embed/fi5qayhXCdA" frameborder="0" allowfullscreen></iframe>
-						<sub>This video created by <a target="_blank" href="https://steemit.com/@nomadics">@nomadics</a></sub>
+						<sub>This video was created by <a target="_blank" href="https://steemit.com/@nomadics">@nomadics</a></sub>
 						
 					</div>
 				</div>
@@ -43,9 +43,9 @@ require_once('he_ad.php');
 				<div class="card">
 					<div class="content">
 
-						<p class="lead"><strong>Schedule Posts:</strong><br> Your time is money...schedule your post in advance, with the help of SteemAuto we'll publish your post whenever you want. <br>Write and plan in advance. .. Leave the rest to Steemauto.</p>
-						<p class="lead"><strong>Fanbase and Curation trail:</strong><br>You can follow famous authors and thier trails, or support them by fanbase, upvote them automatically when they have published a new post. (This will maximise your curation reward)<br>The upvote weight can be adjusted manually. </p>
-						<p class="lead"><strong>Claiming Rewards:</strong><br> Don't have time to check your steem blog? No worries! we can claim (redeem) the post rewards for you. (Your post reward will go into your steem wallet).</p>
+						<p class="lead"><strong>Schedule Posts:</strong><br> Your time is money, so schedule your posts in advance, and with the help of SteemAuto you can publish your post whenever you want. <br>Write and plan in advance...leave the rest to SteemAuto.</p>
+						<p class="lead"><strong>Fanbase and Curation Trails:</strong><br>Follow curation trails and automatically upvote posts that your trail upvotes, or add your favorite authors to your fanbase and automatically upvote every one of their posts. (The upvote weight can be adjusted manually) Using these two features can help maximise your curation rewards.<br></p>
+						<p class="lead"><strong>Claiming Rewards:</strong><br> Don't have time to check your Steem blog? No worries! We can claim the post rewards for you and automatically send them to your Steem wallet.</p>
 						<sub>introduction text contributed by @kingjan</sub>
 					</div>
 				</div>


### PR DESCRIPTION
This fixes all the English capitalization and grammar errors that I could locate on steemauto.com. I also changed wording in some places to help clarify what the writer intended.

I'm not an expert on HTML so you'll probably want to double check where I edited it.

Hope it helps! 

-- [@carn](https://steemit.com/@carn) on Steemit