### PR TITLE
Detect RPC node version and send right methods

### DIFF
--- a/nodejs/config.js
+++ b/nodejs/config.js
@@ -9,6 +9,7 @@ config.rpc = 'ws://127.0.0.1:8090'
 config.rpc2 = 'ws://127.0.0.1:8090'
 config.rpc3 = 'ws://127.0.0.1:8090'
 config.steemd = 'https://steemd.steemitstage.com'
+config.isSteemd = 0 // Use steemd or rpc in the call() method
 config.rpchttp = 'http://127.0.0.1:8090'
 config.nodejssrv = 'http://127.0.0.1'
 

--- a/nodejs/helpers/checkLimits.js
+++ b/nodejs/helpers/checkLimits.js
@@ -6,6 +6,8 @@
 const call = require('./nodeCall')
 const config = require('../config')
 const con = require('../mysql')
+const isSteemd = config.isSteemd
+// we are using isSteemd to change methods for appbase and v0.19.5
 
 let tvfs
 let tvs
@@ -15,8 +17,8 @@ const updateGlobals = async () => {
     // get dynamic global propertise for just appbase! (v0.19.10)
     // will need change in other version nodes
     const result = await call(
-      config.steemd,
-      'condenser_api.get_dynamic_global_properties',
+      isSteemd ? config.steemd : config.rpc,
+      isSteemd ? 'condenser_api.get_dynamic_global_properties' : 'get_dynamic_global_properties',
       []
     )
     // on any error, result will be null
@@ -43,8 +45,8 @@ const checkpowerlimit = async (voter, author, permlink, weight) => {
     // Get accounts information from appbase (v0.19.10)
     // will need change in other versions
     const result = await call(
-      config.steemd,
-      'condenser_api.get_accounts',
+      isSteemd ? config.steemd : config.rpc,
+      isSteemd ? 'condenser_api.get_accounts' : 'get_accounts',
       [
         [voter]
       ]

--- a/nodejs/helpers/streamBlock.js
+++ b/nodejs/helpers/streamBlock.js
@@ -1,6 +1,6 @@
 const call = require('./nodeCall')
 const config = require('../config')
-const isSteemd = 0
+const isSteemd = config.isSteemd
 // I used isSteemd to detect node version and pass right method to the rpc node
 
 const streamBlockNumber = async (cb) => {

--- a/nodejs/helpers/streamBlock.js
+++ b/nodejs/helpers/streamBlock.js
@@ -1,12 +1,14 @@
 const call = require('./nodeCall')
 const config = require('../config')
+const isSteemd = 0
+// I used isSteemd to detect node version and pass right method to the rpc node
 
 const streamBlockNumber = async (cb) => {
   let lastBlock = 0
   setInterval(async () => {
     const result = await call(
-      config.steemd,
-      'condenser_api.get_dynamic_global_properties',
+      isSteemd ? config.steemd : config.rpc,
+      isSteemd ? 'condenser_api.get_dynamic_global_properties' : 'get_dynamic_global_properties',
       []
     )
     if (result && result.head_block_number && !isNaN(result.head_block_number)) {
@@ -21,8 +23,8 @@ const streamBlockNumber = async (cb) => {
 const streamBlockOperations = async (cb) => {
   streamBlockNumber(async blockNumber => {
     const result = await call(
-      config.steemd,
-      'condenser_api.get_block',
+      isSteemd ? config.steemd : config.rpc,
+      isSteemd ? 'condenser_api.get_block' : 'get_block',
       [blockNumber]
     )
     if (result) {

--- a/nodejs/trail.js
+++ b/nodejs/trail.js
@@ -4,6 +4,8 @@ const upvote = require('./helpers/broadcastUpvote')
 const checkLimits = require('./helpers/checkLimits')
 const config = require('./config')
 const con = require('./mysql')
+const isSteemd = config.isSteemd
+// we are using this variable to change methods according to the node version
 
 let trails = []
 
@@ -62,8 +64,8 @@ const trailupvote = async (userr, author, permlink, fweight) => {
   try {
     // get_content which works with just appbase (v0.19.10)
     const content = await call(
-      config.steemd,
-      'condenser_api.get_content',
+      isSteemd ? config.steemd : config.rpc,
+      isSteemd ? 'condenser_api.get_content' : 'get_content',
       [author, permlink]
     )
     // on any possible error, call method will return null


### PR DESCRIPTION
Right now, we have 2 type of nodes: v0.19.5 and v0.19.10
We need to change methods if we change the version of our node!
I want to add a variable to the config file to detect these node change automatically just by passing one variable.